### PR TITLE
Share kubeinformer and clusterinformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 .idea/
 hack/deploy/cert-*
 hack/deploy/controlplane/cert
+.ocmconfig

--- a/config/hub/bootstrap.go
+++ b/config/hub/bootstrap.go
@@ -34,7 +34,7 @@ import (
 	confighelpers "open-cluster-management.io/multicluster-controlplane/config/helpers"
 )
 
-var HubNameSpace = "open-cluster-management-hub"
+var HubNamespace = "open-cluster-management-hub"
 var HubSA = "hub-sa"
 
 //go:embed *.yaml

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/openshift/library-go v0.0.0-20220713145611-ca167a8bd342
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/etcd/server/v3 v3.5.4
@@ -92,7 +93,6 @@ require (
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/hack/start-multicluster-controlplane.sh
+++ b/hack/start-multicluster-controlplane.sh
@@ -4,9 +4,10 @@
 #     Example 2: hack/start-multicluster-controlplane.sh false
 
 KUBE_ROOT=$(pwd)
-SERVING_IP=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*')
 if [[ "$(uname)" == "Darwin" ]]; then
     SERVING_IP=$(ifconfig en0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*')
+else
+    SERVING_IP=$(ifconfig eth0 | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*')
 fi
 
 if [ ! $SERVING_IP ] ; then

--- a/pkg/apiserver/aggregator.go
+++ b/pkg/apiserver/aggregator.go
@@ -162,7 +162,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 	err = aggregatorServer.GenericAPIServer.AddPostStartHook("kube-controller", func(context genericapiserver.PostStartHookContext) error {
 		controllerConfig := rest.CopyConfig(aggregatorConfig.GenericConfig.LoopbackClientConfig)
 		go func() {
-			err := kubecontroller.RunKubeControllers(controllerConfig, clientCert, clientKey)
+			err := kubecontroller.RunKubeControllers(controllerConfig, aggregatorConfig.GenericConfig.SharedInformerFactory, clientCert, clientKey)
 			if err != nil {
 				klog.Errorf("run kube controller error: %v", err)
 			}

--- a/pkg/apiserver/aggregator.go
+++ b/pkg/apiserver/aggregator.go
@@ -233,35 +233,22 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 	}
 
 	// Add PostStartHook to install registration controllers
-	err = aggregatorServer.GenericAPIServer.AddPostStartHook("multicluster-controlplane-registration-controllers", func(context genericapiserver.PostStartHookContext) error {
+	err = aggregatorServer.GenericAPIServer.AddPostStartHook("multicluster-controlplane-controllers", func(context genericapiserver.PostStartHookContext) error {
+
 		// Start controllers
 		controllerConfig := rest.CopyConfig(aggregatorConfig.GenericConfig.LoopbackClientConfig)
 		controllerConfig.ContentType = "application/json"
 
 		go func() {
-			if err := ocmcontroller.InstallRegistraionControllers(goContext(context), controllerConfig); err != nil {
-				klog.Errorf("failed to bootstrap ocm registration controllers: %v", err)
+			if err := ocmcontroller.InstallOCMControllers(
+				goContext(context),
+				controllerConfig,
+				kubeClient,
+				aggregatorConfig.GenericConfig.SharedInformerFactory,
+			); err != nil {
+				klog.Errorf("failed to bootstrap ocm controllers: %v", err)
 			} else {
-				klog.Infof("Finished bootstrapping ocm registration controllers")
-			}
-		}()
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Add PostStartHook to install placement controllers
-	err = aggregatorServer.GenericAPIServer.AddPostStartHook("multicluster-controlplane-placement-controllers", func(context genericapiserver.PostStartHookContext) error {
-		// Start controllers
-		controllerConfig := rest.CopyConfig(aggregatorConfig.GenericConfig.LoopbackClientConfig)
-		controllerConfig.ContentType = "application/json"
-
-		go func() {
-			if err := ocmcontroller.InstallPlacementControllers(goContext(context), controllerConfig); err != nil {
-				klog.Errorf("failed to bootstrap ocm placement controllers: %v", err)
-			} else {
-				klog.Infof("Finished bootstrapping ocm placement controllers")
+				klog.Infof("Finished bootstrapping ocm controllers")
 			}
 		}()
 		return nil

--- a/pkg/apiserver/aggregator.go
+++ b/pkg/apiserver/aggregator.go
@@ -232,7 +232,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		return nil, err
 	}
 
-	// Add PostStartHook to install registration controllers
+	// Add PostStartHook to install ocm controllers
 	err = aggregatorServer.GenericAPIServer.AddPostStartHook("multicluster-controlplane-controllers", func(context genericapiserver.PostStartHookContext) error {
 
 		// Start controllers

--- a/pkg/controllers/ocmcontroller/ocmcontroller.go
+++ b/pkg/controllers/ocmcontroller/ocmcontroller.go
@@ -227,6 +227,7 @@ func InstallOCMControllers(ctx context.Context, kubeConfig *rest.Config,
 	go clusterInformers.Start(ctx.Done())
 	go workInformers.Start(ctx.Done())
 	go addOnInformers.Start(ctx.Done())
+	go kubeInfomers.Start(ctx.Done())
 
 	go managedClusterController.Run(ctx, 1)
 	go taintController.Run(ctx, 1)

--- a/pkg/controllers/ocmcontroller/ocmcontroller.go
+++ b/pkg/controllers/ocmcontroller/ocmcontroller.go
@@ -227,7 +227,6 @@ func InstallOCMControllers(ctx context.Context, kubeConfig *rest.Config,
 	go clusterInformers.Start(ctx.Done())
 	go workInformers.Start(ctx.Done())
 	go addOnInformers.Start(ctx.Done())
-	go kubeInfomers.Start(ctx.Done())
 
 	go managedClusterController.Run(ctx, 1)
 	go taintController.Run(ctx, 1)

--- a/pkg/controllers/ocmcontroller/ocmcontroller.go
+++ b/pkg/controllers/ocmcontroller/ocmcontroller.go
@@ -3,38 +3,248 @@ package ocmcontroller
 
 import (
 	"context"
+	"net/http"
 	_ "net/http/pprof"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/pkg/errors"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	placement "open-cluster-management.io/placement/pkg/controllers"
-	registration "open-cluster-management.io/registration/pkg/hub"
+	kubeevents "k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
+	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterscheme "open-cluster-management.io/api/client/cluster/clientset/versioned/scheme"
+	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	workv1client "open-cluster-management.io/api/client/work/clientset/versioned"
+	workv1informers "open-cluster-management.io/api/client/work/informers/externalversions"
+	ocmfeature "open-cluster-management.io/api/feature"
+	scheduling "open-cluster-management.io/placement/pkg/controllers/scheduling"
+	"open-cluster-management.io/placement/pkg/debugger"
+	"open-cluster-management.io/registration/pkg/features"
+	"open-cluster-management.io/registration/pkg/helpers"
+	"open-cluster-management.io/registration/pkg/hub/addon"
+	"open-cluster-management.io/registration/pkg/hub/clusterrole"
+	"open-cluster-management.io/registration/pkg/hub/csr"
+	"open-cluster-management.io/registration/pkg/hub/lease"
+	"open-cluster-management.io/registration/pkg/hub/managedcluster"
+	"open-cluster-management.io/registration/pkg/hub/managedclusterset"
+	"open-cluster-management.io/registration/pkg/hub/managedclustersetbinding"
+	"open-cluster-management.io/registration/pkg/hub/rbacfinalizerdeletion"
+	"open-cluster-management.io/registration/pkg/hub/taint"
 
 	confighub "open-cluster-management.io/multicluster-controlplane/config/hub"
 )
 
-func InstallRegistraionControllers(ctx context.Context, kubeConfig *rest.Config) error {
+var ResyncInterval = 5 * time.Minute
+
+func InstallOCMControllers(ctx context.Context, kubeConfig *rest.Config,
+	kubeClient kubernetes.Interface, kubeInfomers kubeinformers.SharedInformerFactory) error {
 	eventRecorder := events.NewInMemoryRecorder("registration-controller")
 
 	controllerContext := &controllercmd.ControllerContext{
 		KubeConfig:        kubeConfig,
 		EventRecorder:     eventRecorder,
-		OperatorNamespace: confighub.HubNameSpace,
+		OperatorNamespace: confighub.HubNamespace,
 	}
 
-	return registration.RunControllerManager(ctx, controllerContext)
-}
-
-func InstallPlacementControllers(ctx context.Context, kubeConfig *rest.Config) error {
-	eventRecorder := events.NewInMemoryRecorder("placement-controller")
-
-	controllerContext := &controllercmd.ControllerContext{
-		KubeConfig:        kubeConfig,
-		EventRecorder:     eventRecorder,
-		OperatorNamespace: confighub.HubNameSpace,
+	clusterClient, err := clusterv1client.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
 	}
 
-	return placement.RunControllerManager(ctx, controllerContext)
+	workClient, err := workv1client.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	addOnClient, err := addonclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	clusterInformers := clusterv1informers.NewSharedInformerFactory(clusterClient, 10*time.Minute)
+	workInformers := workv1informers.NewSharedInformerFactory(workClient, 10*time.Minute)
+	addOnInformers := addoninformers.NewSharedInformerFactory(addOnClient, 10*time.Minute)
+
+	managedClusterController := managedcluster.NewManagedClusterController(
+		kubeClient,
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		controllerContext.EventRecorder,
+	)
+
+	taintController := taint.NewTaintController(
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		controllerContext.EventRecorder,
+	)
+
+	var csrController factory.Controller
+	if features.DefaultHubMutableFeatureGate.Enabled(ocmfeature.V1beta1CSRAPICompatibility) {
+		v1CSRSupported, v1beta1CSRSupported, err := helpers.IsCSRSupported(kubeClient)
+		if err != nil {
+			return errors.Wrapf(err, "failed CSR api discovery")
+		}
+
+		if !v1CSRSupported && v1beta1CSRSupported {
+			csrController = csr.NewV1beta1CSRApprovingController(
+				kubeClient,
+				kubeInfomers.Certificates().V1beta1().CertificateSigningRequests(),
+				controllerContext.EventRecorder,
+			)
+			klog.Info("Using v1beta1 CSR api to manage spoke client certificate")
+		}
+	}
+	if csrController == nil {
+		csrController = csr.NewCSRApprovingController(
+			kubeClient,
+			kubeInfomers.Certificates().V1().CertificateSigningRequests(),
+			controllerContext.EventRecorder,
+		)
+	}
+
+	leaseController := lease.NewClusterLeaseController(
+		kubeClient,
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		kubeInfomers.Coordination().V1().Leases(),
+		ResyncInterval, //TODO: this interval time should be allowed to change from outside
+		controllerContext.EventRecorder,
+	)
+
+	rbacFinalizerController := rbacfinalizerdeletion.NewFinalizeController(
+		kubeInfomers.Rbac().V1().Roles(),
+		kubeInfomers.Rbac().V1().RoleBindings(),
+		kubeInfomers.Core().V1().Namespaces().Lister(),
+		clusterInformers.Cluster().V1().ManagedClusters().Lister(),
+		workInformers.Work().V1().ManifestWorks().Lister(),
+		kubeClient.RbacV1(),
+		controllerContext.EventRecorder,
+	)
+
+	managedClusterSetController := managedclusterset.NewManagedClusterSetController(
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+		controllerContext.EventRecorder,
+	)
+
+	managedClusterSetBindingController := managedclustersetbinding.NewManagedClusterSetBindingController(
+		clusterClient,
+		clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSetBindings(),
+		controllerContext.EventRecorder,
+	)
+
+	clusterroleController := clusterrole.NewManagedClusterClusterroleController(
+		kubeClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		kubeInfomers.Rbac().V1().ClusterRoles(),
+		controllerContext.EventRecorder,
+	)
+
+	addOnHealthCheckController := addon.NewManagedClusterAddOnHealthCheckController(
+		addOnClient,
+		addOnInformers.Addon().V1alpha1().ManagedClusterAddOns(),
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		controllerContext.EventRecorder,
+	)
+
+	addOnFeatureDiscoveryController := addon.NewAddOnFeatureDiscoveryController(
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		addOnInformers.Addon().V1alpha1().ManagedClusterAddOns(),
+		controllerContext.EventRecorder,
+	)
+
+	var defaultManagedClusterSetController, globalManagedClusterSetController factory.Controller
+	if features.DefaultHubMutableFeatureGate.Enabled(ocmfeature.DefaultClusterSet) {
+		defaultManagedClusterSetController = managedclusterset.NewDefaultManagedClusterSetController(
+			clusterClient.ClusterV1beta1(),
+			clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+			controllerContext.EventRecorder,
+		)
+		globalManagedClusterSetController = managedclusterset.NewGlobalManagedClusterSetController(
+			clusterClient.ClusterV1beta1(),
+			clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+			controllerContext.EventRecorder,
+		)
+	}
+
+	broadcaster := kubeevents.NewBroadcaster(&kubeevents.EventSinkImpl{Interface: kubeClient.EventsV1()})
+
+	broadcaster.StartRecordingToSink(ctx.Done())
+
+	recorder := broadcaster.NewRecorder(clusterscheme.Scheme, "placementController")
+
+	scheduler := scheduling.NewPluginScheduler(
+		scheduling.NewSchedulerHandler(
+			clusterClient,
+			clusterInformers.Cluster().V1beta1().PlacementDecisions().Lister(),
+			clusterInformers.Cluster().V1alpha1().AddOnPlacementScores().Lister(),
+			clusterInformers.Cluster().V1().ManagedClusters().Lister(),
+			recorder),
+	)
+
+	if controllerContext.Server != nil {
+		debug := debugger.NewDebugger(
+			scheduler,
+			clusterInformers.Cluster().V1beta1().Placements(),
+			clusterInformers.Cluster().V1().ManagedClusters(),
+		)
+
+		controllerContext.Server.Handler.NonGoRestfulMux.HandlePrefix(debugger.DebugPath,
+			http.HandlerFunc(debug.Handler))
+	}
+
+	schedulingController := scheduling.NewSchedulingController(
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSetBindings(),
+		clusterInformers.Cluster().V1beta1().Placements(),
+		clusterInformers.Cluster().V1beta1().PlacementDecisions(),
+		scheduler,
+		controllerContext.EventRecorder, recorder,
+	)
+
+	schedulingControllerResync := scheduling.NewSchedulingControllerResync(
+		clusterClient,
+		clusterInformers.Cluster().V1().ManagedClusters(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+		clusterInformers.Cluster().V1beta1().ManagedClusterSetBindings(),
+		clusterInformers.Cluster().V1beta1().Placements(),
+		clusterInformers.Cluster().V1beta1().PlacementDecisions(),
+		scheduler,
+		controllerContext.EventRecorder, recorder,
+	)
+	go clusterInformers.Start(ctx.Done())
+	go workInformers.Start(ctx.Done())
+	go addOnInformers.Start(ctx.Done())
+
+	go managedClusterController.Run(ctx, 1)
+	go taintController.Run(ctx, 1)
+	go csrController.Run(ctx, 1)
+	go leaseController.Run(ctx, 1)
+	go rbacFinalizerController.Run(ctx, 1)
+	go managedClusterSetController.Run(ctx, 1)
+	go managedClusterSetBindingController.Run(ctx, 1)
+	go clusterroleController.Run(ctx, 1)
+	go addOnHealthCheckController.Run(ctx, 1)
+	go addOnFeatureDiscoveryController.Run(ctx, 1)
+	if features.DefaultHubMutableFeatureGate.Enabled(ocmfeature.DefaultClusterSet) {
+		go defaultManagedClusterSetController.Run(ctx, 1)
+		go globalManagedClusterSetController.Run(ctx, 1)
+	}
+	go schedulingController.Run(ctx, 1)
+	go schedulingControllerResync.Run(ctx, 1)
+
+	<-ctx.Done()
+	return nil
 }


### PR DESCRIPTION
1. share kubeinformer and clusterinformer by registration controller and placement controller
2. share kubeinfomer by kube controller manager

It can save ~10Mi memory with 1 single managed cluster.

Signed-off-by: clyang82 <chuyang@redhat.com>