### PR TITLE
fixed the issues that e2e test is not stable

### DIFF
--- a/test/bin/setup.sh
+++ b/test/bin/setup.sh
@@ -62,6 +62,8 @@ for i in $(seq 1 "${number}"); do
   printf "\033[0;32m%s\n\033[0m" "## Deploy standalone addon in namespace $namespace"
   # wait the controplane api-server is ready
   wait_appear "$KUBECTL get pod -n $namespace -l app=multicluster-controlplane --ignore-not-found | grep Running || true"
+  kube::util::wait_for_url "https://${external_host_ip}:${external_host_port}/healthz" "apiserver: " 1 60 1 || { echo "Controlplane $namespace is not ready!" ; exit 1 ; }
+
   cd $project_dir
   mkdir ${project_dir}/hack/deploy/cert-${namespace}
   cp ${kubeconfig_dir}/${namespace} ${project_dir}/hack/deploy/cert-${namespace}/kubeconfig # for makefile

--- a/test/bin/setup.sh
+++ b/test/bin/setup.sh
@@ -78,6 +78,7 @@ for i in $(seq 1 "${number}"); do
   token=$(echo $output | awk -F ' ' '{print $1}' | awk -F '=' '{print $2}')
   # join the controlplane
   clusteradm --kubeconfig=${kubeconfig_dir}/${namespace}-mc1 join --hub-token $token --hub-apiserver "https://${external_host_ip}:${external_host_port}" --cluster-name ${namespace}-mc1 --wait
+  wait_appear "$KUBECTL --kubeconfig=${kubeconfig_dir}/${namespace} get csr --ignore-not-found | grep ^${namespace}-mc1 || true"
   clusteradm --kubeconfig=${kubeconfig_dir}/${namespace} accept --clusters ${namespace}-mc1
 done
 


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
E2E test is not stable sometimes. There are perhaps three reasons for the problem:
  1. Deploy the resources on the API Server when it is not ready.
  2. The CSR resource is accepted on the hub control plane but has not been created in the hub control plane.
  3. Addon CRD is not created when deploying the resources of the addon. This error will not occur if the [all-in-one pr](https://github.com/open-cluster-management-io/multicluster-controlplane/pull/20) is merged.
  
Ref: https://github.com/open-cluster-management-io/multicluster-controlplane/pull/19
