### PR TITLE
add managed serviceaccount addon test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,5 +128,5 @@ cleanup-integration:
 .PHONY: cleanup-integration
 
 test-integration:
-	./test/bin/test-integration.sh -v $(VERBOSE)
+	./test/bin/test-integration.sh -v $(VERBOSE) -f "!addon"
 .PHONY: test-integration

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc // indirect
@@ -182,13 +183,14 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
-	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 // indirect
+	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/tools v0.2.0 // indirect
 	k8s.io/controller-manager v0.25.4
 	k8s.io/kube-controller-manager v0.0.0
+	open-cluster-management.io/managed-serviceaccount v0.2.1-0.20220427065210-de6a7b7b5be8
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -556,7 +557,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -661,7 +661,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -832,8 +833,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 h1:vJ2V3lFLg+bBhgroYuRfyN583UzVveQmIXjc8T/y3to=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1286,8 +1287,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -1414,6 +1415,8 @@ open-cluster-management.io/api v0.9.0 h1:JQidCTMY3RdS0m3UDP24j6ykNpxWJ20LEdNtbxJ
 open-cluster-management.io/api v0.9.0/go.mod h1:+OEARSAl2jIhuLItUcS30UgLA3khmA9ihygLVxzEn+U=
 open-cluster-management.io/clusteradm v0.4.0 h1:UqTgXy7o/Tps1tJNNHbkjVRCFP+4cvn79w7tkoHEvAA=
 open-cluster-management.io/clusteradm v0.4.0/go.mod h1:nodp4RjHy/94guw4eLiYiZzpmk1D5ExXnZogGSHygoA=
+open-cluster-management.io/managed-serviceaccount v0.2.1-0.20220427065210-de6a7b7b5be8 h1:foP5RkSec9DkUA8sJ5FLna5We8VxJyu0179id5zNXgA=
+open-cluster-management.io/managed-serviceaccount v0.2.1-0.20220427065210-de6a7b7b5be8/go.mod h1:JQfA1L6GaYXaSaw/c4VY4GTgj8kqJx8cEeD4e/0M5gU=
 open-cluster-management.io/placement v0.9.0 h1:pLt8iUboxDdL++i0fcrJu/gm0pvdV5vIeJFJSddcs3w=
 open-cluster-management.io/placement v0.9.0/go.mod h1:SK7KuFptb3rj2che6FKjyjWj0w4VyDS1atHQcZVnX6U=
 open-cluster-management.io/registration v0.9.1-0.20221114013223-9878ed071a3b h1:UVMyYSjCn0VakSC/MGX2THCp0D1HjR7iferG4EhCxtA=

--- a/test/bin/test-integration.sh
+++ b/test/bin/test-integration.sh
@@ -46,7 +46,7 @@ cd ${project_dir}/test/e2e
 if [ -z "${filter}" ]; then
   ./e2e.test --options=$options_file -v=$verbose
 else
-  ./e2e.test --label-filter=${filter} --options=$options_file -v=$verbose
+  ./e2e.test --ginkgo.label-filter=${filter} --ginkgo.v --options=$options_file -v=$verbose 
 fi
 
 rm ${project_dir}/test/e2e/e2e.test

--- a/test/e2e/managed_cluster_test.go
+++ b/test/e2e/managed_cluster_test.go
@@ -13,7 +13,7 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = ginkgo.Describe("ManagedCluster", func() {
+var _ = ginkgo.Describe("ManagedCluster", ginkgo.Label("cluster"), func() {
 	ginkgo.It("get managed clusters from controlPlanes", func() {
 		gomega.Eventually(func() bool {
 			availableCount := 0

--- a/test/e2e/managed_cluster_test.go
+++ b/test/e2e/managed_cluster_test.go
@@ -3,64 +3,34 @@ package e2e_test
 
 import (
 	"context"
+	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = ginkgo.Describe("ManagedCluster", func() {
-	var runtimeClientMap map[string]runtimeClient.Client
+	ginkgo.It("get managed clusters from controlPlanes", func() {
+		gomega.Eventually(func() bool {
+			availableCount := 0
+			for _, controlPlane := range options.ControlPlanes {
+				managedCluster := clusterv1.ManagedCluster{}
+				managedCluster.SetName(controlPlane.ManagedCluster[0].Name)
+				client := runtimeClientMap[controlPlane.Name]
+				err := client.Get(context.TODO(), runtimeClient.ObjectKeyFromObject(&managedCluster), &managedCluster)
+				gomega.Expect(err).Should(gomega.BeNil())
+				gomega.Expect(len(managedCluster.GetUID()) > 0).Should(gomega.BeTrue())
 
-	ginkgo.BeforeEach(func() {
-		runtimeClientMap = make(map[string]runtimeClient.Client, 0)
-
-		for _, controlPlane := range options.ControlPlanes {
-			ginkgo.By("Ensure each controlplane with a managed cluster")
-			gomega.Expect(len(controlPlane.Name) > 0).Should(gomega.BeTrue())
-			gomega.Expect(len(controlPlane.ManagedCluster) == 1).Should(gomega.BeTrue())
-
-			ginkgo.By("Get the client of the controlplane")
-			client, err := getRuntimeClient(controlPlane.KubeConfig, controlPlane.Context)
-			gomega.Expect(err).Should(gomega.BeNil())
-			runtimeClientMap[controlPlane.Name] = client
-		}
-
-		gomega.Expect(len(runtimeClientMap) > 0).Should(gomega.BeTrue())
-	})
-
-	ginkgo.It("get managed clusters from controlplanes", func() {
-		testControlPlane := 0
-		for _, controlPlane := range options.ControlPlanes {
-			managedCluster := clusterv1.ManagedCluster{}
-			managedCluster.SetName(controlPlane.ManagedCluster[0].Name)
-			client := runtimeClientMap[controlPlane.Name]
-
-			err := client.Get(context.TODO(), runtimeClient.ObjectKeyFromObject(&managedCluster), &managedCluster)
-			gomega.Expect(err).Should(gomega.BeNil())
-			gomega.Expect(len(managedCluster.GetUID()) > 0).Should(gomega.BeTrue())
-			testControlPlane++
-		}
-		gomega.Expect(testControlPlane > 0).Should(gomega.BeTrue())
+				if meta.IsStatusConditionTrue(managedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable) {
+					klog.V(5).Infof("%s is available on %s", controlPlane.ManagedCluster[0].Name, controlPlane.Name)
+					availableCount++
+				}
+			}
+			return availableCount > 0 && availableCount == len(options.ControlPlanes)
+		}).WithTimeout(30 * time.Second).Should(gomega.BeTrue())
 	})
 })
-
-func getRuntimeClient(kubeconfig, kubecontext string) (runtimeClient.Client, error) {
-	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{
-			ExplicitPath: kubeconfig,
-		},
-		&clientcmd.ConfigOverrides{
-			CurrentContext: kubecontext,
-		}).ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := runtimeClient.New(restConfig, runtimeClient.Options{Scheme: runtimeScheme})
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}

--- a/test/e2e/managed_serviceaccount_test.go
+++ b/test/e2e/managed_serviceaccount_test.go
@@ -20,7 +20,7 @@ import (
 	msacommon "open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
 
-var _ = ginkgo.Describe("ManagedServiceAccount", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("ManagedServiceAccount", ginkgo.Label("addon"), ginkgo.Ordered, func() {
 	var controlPlane ControlPlane
 	var managedCluster Cluster
 	var msaName string
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe("ManagedServiceAccount", ginkgo.Ordered, func() {
 		msaName = "msa-e2e"
 	})
 
-	ginkgo.It("managed-serviceaccount addon should available", func() {
+	ginkgo.It("managed-serviceaccount addon should be available", func() {
 		availableCount := 0
 		for _, controlPlane := range options.ControlPlanes {
 			addon := &addonv1alpha1.ManagedClusterAddOn{}

--- a/test/e2e/managed_serviceaccount_test.go
+++ b/test/e2e/managed_serviceaccount_test.go
@@ -1,0 +1,182 @@
+// Copyright Contributors to the Open Cluster Management project
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	msav1alpha1 "open-cluster-management.io/managed-serviceaccount/api/v1alpha1"
+	msacommon "open-cluster-management.io/managed-serviceaccount/pkg/common"
+)
+
+var _ = ginkgo.Describe("ManagedServiceAccount", ginkgo.Ordered, func() {
+	var controlPlane ControlPlane
+	var managedCluster Cluster
+	var msaName string
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(len(options.ControlPlanes) > 0).Should(gomega.BeTrue())
+		controlPlane = options.ControlPlanes[0]
+		gomega.Expect(len(options.ControlPlanes[0].ManagedCluster) > 0).Should(gomega.BeTrue())
+		managedCluster = options.ControlPlanes[0].ManagedCluster[0]
+		msaName = "msa-e2e"
+	})
+
+	ginkgo.It("managed-serviceaccount addon should available", func() {
+		availableCount := 0
+		for _, controlPlane := range options.ControlPlanes {
+			addon := &addonv1alpha1.ManagedClusterAddOn{}
+			runtimeClient := runtimeClientMap[controlPlane.Name]
+			err := runtimeClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: controlPlane.ManagedCluster[0].Name,
+				Name:      msacommon.AddonName,
+			}, addon)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if meta.IsStatusConditionTrue(addon.Status.Conditions, addonv1alpha1.ManagedClusterAddOnConditionAvailable) {
+				klog.V(5).Infof("managed-serviceaccount addon is available on %s", controlPlane.Name)
+				availableCount++
+			}
+		}
+		gomega.Expect(availableCount > 0).Should(gomega.BeTrue())
+		gomega.Expect(availableCount == len(options.ControlPlanes)).Should(gomega.BeTrue())
+	})
+
+	// https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token
+	ginkgo.It("token projection should work ", func() {
+		ginkgo.By("Create a ManagedServiceAccount on the hub cluster")
+		msa := &msav1alpha1.ManagedServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: managedCluster.Name,
+				Name:      msaName,
+			},
+			Spec: msav1alpha1.ManagedServiceAccountSpec{
+				Rotation: msav1alpha1.ManagedServiceAccountRotation{
+					Enabled:  true,
+					Validity: metav1.Duration{Duration: time.Minute * 30},
+				},
+			},
+		}
+		err := runtimeClientMap[controlPlane.Name].Create(context.TODO(), msa)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Check the ServiceAccount on the managed cluster")
+		gomega.Eventually(func() error {
+			return runtimeClientMap[managedCluster.Name].Get(context.TODO(), types.NamespacedName{
+				Namespace: msacommon.AddonAgentInstallNamespace,
+				Name:      msaName,
+			}, &corev1.ServiceAccount{})
+		}).WithTimeout(30 * time.Second).ShouldNot(gomega.HaveOccurred())
+
+		ginkgo.By("Validate the status of ManagedServiceAccount")
+		gomega.Eventually(func() error {
+			msa := &msav1alpha1.ManagedServiceAccount{}
+			if err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+				Namespace: managedCluster.Name,
+				Name:      msaName,
+			}, msa); err != nil {
+				return err
+			}
+			if !meta.IsStatusConditionTrue(msa.Status.Conditions, msav1alpha1.ConditionTypeSecretCreated) {
+				return fmt.Errorf("the secret: %s/%s has not been created in hub", managedCluster.Name, msaName)
+			}
+			if !meta.IsStatusConditionTrue(msa.Status.Conditions, msav1alpha1.ConditionTypeTokenReported) {
+				return fmt.Errorf("the token has not been reported to secret: %s/%s", managedCluster.Name, msaName)
+			}
+			if msa.Status.TokenSecretRef == nil {
+				return fmt.Errorf("the ManagedServiceAccount not associated any token secret")
+			}
+			return nil
+		}).WithTimeout(30 * time.Second).ShouldNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("validity of the signing token", func() {
+		ginkgo.By("Get the ManagedServiceAccount")
+		msa := &msav1alpha1.ManagedServiceAccount{}
+		err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+			Namespace: managedCluster.Name,
+			Name:      msaName,
+		}, msa)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Eventually(func() error {
+			ginkgo.By("Get the reported token")
+			secret := &corev1.Secret{}
+			if err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+				Namespace: managedCluster.Name,
+				Name:      msa.Status.TokenSecretRef.Name,
+			}, secret); err != nil {
+				return err
+			}
+			token := secret.Data[corev1.ServiceAccountTokenKey]
+
+			ginkgo.By("Validate the reported token by calling the TokenReview api of the managed cluster")
+			tokenReview := &authv1.TokenReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "TokenReview",
+					APIVersion: "authentication.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "token-review-request",
+				},
+				Spec: authv1.TokenReviewSpec{
+					Token: string(token),
+				},
+			}
+			if err := runtimeClientMap[managedCluster.Name].Create(context.TODO(), tokenReview); err != nil {
+				return err
+			}
+
+			if !tokenReview.Status.Authenticated {
+				return fmt.Errorf("the secret: %s/%s token should be authenticated by the managed cluster service account", secret.GetNamespace(), secret.GetName())
+			}
+			expectUserName := fmt.Sprintf("system:serviceaccount:%s:%s", msacommon.AddonAgentInstallNamespace, msaName)
+			if tokenReview.Status.User.Username != expectUserName {
+				return fmt.Errorf("expect username: %s of the token, but got username: %s", expectUserName, tokenReview.Status.User.Username)
+			}
+			return nil
+		}).WithTimeout(30 * time.Second).ShouldNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterAll(func() {
+		ginkgo.By("Delete the ManagedServiceAccount")
+		msa := &msav1alpha1.ManagedServiceAccount{}
+		err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+			Namespace: managedCluster.Name,
+			Name:      msaName,
+		}, msa)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		err = runtimeClientMap[controlPlane.Name].Delete(context.TODO(), msa)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		ginkgo.By("Reported secret should be deleted on hub cluster")
+		gomega.Eventually(func() bool {
+			secret := &corev1.Secret{}
+			err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+				Namespace: msa.GetNamespace(),
+				Name:      msa.Status.TokenSecretRef.Name,
+			}, secret)
+			return errors.IsNotFound(err)
+		}, time.Minute, time.Second).Should(gomega.BeTrue())
+
+		ginkgo.By("ServiceAccount should be deleted on managed cluster")
+		gomega.Eventually(func() bool {
+			serviceAccount := &corev1.ServiceAccount{}
+			err := runtimeClientMap[controlPlane.Name].Get(context.TODO(), types.NamespacedName{
+				Namespace: msacommon.AddonAgentInstallNamespace,
+				Name:      msaName,
+			}, serviceAccount)
+			return errors.IsNotFound(err)
+		}, time.Minute, time.Second).Should(gomega.BeTrue())
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -13,15 +13,20 @@ import (
 	gomega "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	msav1alpha1 "open-cluster-management.io/managed-serviceaccount/api/v1alpha1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	options       Options
-	timeout       time.Duration
-	file          string
-	runtimeScheme *runtime.Scheme
+	options          Options
+	timeout          time.Duration
+	file             string
+	runtimeClientMap map[string]runtimeClient.Client
 )
 
 func TestE2E(t *testing.T) {
@@ -37,12 +42,38 @@ func init() {
 
 var _ = ginkgo.BeforeSuite(func() {
 	initVars()
-	addScheme()
+	initRuntimeClients(addScheme())
 })
 
-func addScheme() {
-	runtimeScheme = runtime.NewScheme()
+func addScheme() *runtime.Scheme {
+	runtimeScheme := runtime.NewScheme()
+	gomega.Expect(kubescheme.AddToScheme(runtimeScheme)).Should(gomega.BeNil())
 	gomega.Expect(clusterv1.AddToScheme(runtimeScheme)).Should(gomega.BeNil())
+	gomega.Expect(addonv1alpha1.AddToScheme(runtimeScheme)).Should(gomega.BeNil())
+	gomega.Expect(msav1alpha1.AddToScheme(runtimeScheme)).Should(gomega.BeNil())
+	return runtimeScheme
+}
+
+func initRuntimeClients(scheme *runtime.Scheme) {
+	runtimeClientMap = make(map[string]runtimeClient.Client, 0)
+
+	for _, controlPlane := range options.ControlPlanes {
+		ginkgo.By("Ensure each controlplane with a managed cluster")
+		gomega.Expect(len(controlPlane.Name) > 0).Should(gomega.BeTrue())
+		gomega.Expect(len(controlPlane.ManagedCluster) == 1).Should(gomega.BeTrue())
+
+		ginkgo.By("Get the client of the controlplane")
+		client, err := getRuntimeClient(controlPlane.KubeConfig, scheme)
+		gomega.Expect(err).Should(gomega.BeNil())
+		runtimeClientMap[controlPlane.Name] = client
+
+		ginkgo.By("Get the client of the managedcluster")
+		client, err = getRuntimeClient(controlPlane.ManagedCluster[0].KubeConfig, scheme)
+		gomega.Expect(err).Should(gomega.BeNil())
+		runtimeClientMap[controlPlane.ManagedCluster[0].Name] = client
+	}
+
+	gomega.Expect(len(runtimeClientMap) > 0).Should(gomega.BeTrue())
 }
 
 func initVars() {
@@ -82,4 +113,16 @@ type Cluster struct {
 	Name       string `yaml:"name,omitempty"`
 	Context    string `yaml:"context,omitempty"`
 	KubeConfig string `yaml:"kubeconfig,omitempty"`
+}
+
+func getRuntimeClient(kubeconfig string, runtimeScheme *runtime.Scheme) (runtimeClient.Client, error) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	client, err := runtimeClient.New(restConfig, runtimeClient.Options{Scheme: runtimeScheme})
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
 }


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Reference: https://github.com/open-cluster-management-io/multicluster-controlplane/issues/22

Since the managed service account addon hasn't been [integrated into the control-plane binary](https://github.com/open-cluster-management-io/multicluster-controlplane/pull/20). We will skip the addon test in the integration test for now.