### PR TITLE
fixed the issue that external etcd is not ready

### DIFF
--- a/hack/deploy-etcd.sh
+++ b/hack/deploy-etcd.sh
@@ -65,7 +65,6 @@ function check_multicluster-etcd {
     for i in {1..50}; do
         echo "Checking multicluster-etcd..."
         RESULT=$(${KUBECTL} -n ${ETCD_NS} exec etcd-0 -- etcdctl cluster-health | tail -n1)
-        echo "checking result #$RESULT#"
         if [[ "${RESULT}" = "cluster is healthy" ]]; then
             echo "#### multicluster-etcd ${ETCD_NS} is ready ####"
             break

--- a/hack/deploy-etcd.sh
+++ b/hack/deploy-etcd.sh
@@ -62,16 +62,17 @@ ${KUSTOMIZE} build ${KUBE_ROOT}/hack/deploy/etcd | ${KUBECTL} apply -f -
 mv hack/deploy/etcd/kustomization.yaml.tmp hack/deploy/etcd/kustomization.yaml
 
 function check_multicluster-etcd {
-    for i in {1..20}; do
+    for i in {1..50}; do
         echo "Checking multicluster-etcd..."
         RESULT=$(${KUBECTL} -n ${ETCD_NS} exec etcd-0 -- etcdctl cluster-health | tail -n1)
-        if [  "${RESULT}" = "cluster is healthy" ]; then
+        echo "checking result #$RESULT#"
+        if [[ "${RESULT}" = "cluster is healthy" ]]; then
             echo "#### multicluster-etcd ${ETCD_NS} is ready ####"
             break
         fi
         
-        if [ $i -eq 20 ]; then
-            echo "!!!!!!!!!!  the multicluster-etcd ${ETCD_NS} is not ready within 60s"
+        if [ $i -eq 30 ]; then
+            echo "!!!!!!!!!!  the multicluster-etcd ${ETCD_NS} is not ready within 100s"
             ${KUBECTL} -n ${ETCD_NS} get pods
             
             exit 1

--- a/hack/deploy-etcd.sh
+++ b/hack/deploy-etcd.sh
@@ -70,7 +70,7 @@ function check_multicluster-etcd {
             break
         fi
         
-        if [ $i -eq 30 ]; then
+        if [ $i -eq 50 ]; then
             echo "!!!!!!!!!!  the multicluster-etcd ${ETCD_NS} is not ready within 100s"
             ${KUBECTL} -n ${ETCD_NS} get pods
             

--- a/hack/deploy/etcd/statefulset.yaml
+++ b/hack/deploy/etcd/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
   - metadata:
       name: multicluster-config
     spec:
-      storageClassName: gp2
+      storageClassName: standard
       accessModes:
         - "ReadWriteOnce"
       resources:

--- a/hack/deploy/etcd/statefulset.yaml
+++ b/hack/deploy/etcd/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
   - metadata:
       name: multicluster-config
     spec:
-      storageClassName: standard
+      storageClassName: gp2
       accessModes:
         - "ReadWriteOnce"
       resources:


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>
Reference: https://github.com/open-cluster-management-io/multicluster-controlplane/pull/33
Error message:
```bash
Checking multicluster-etcd...
Error:  client: etcd cluster is unavailable or misconfigured; error #0: dial tcp 127.0.0.1:4001: getsockopt: connection refused
; error #1: dial tcp 127.0.0.1:2379: getsockopt: connection refused

error #0: dial tcp 127.0.0.1:4001: getsockopt: connection refused
error #1: dial tcp 127.0.0.1:2379: getsockopt: connection refused

command terminated with exit code 4
!!!!!!!!!!  the multicluster-etcd multicluster-controlplane-etcd is not ready within 60s
```