### PR TITLE
enable registration agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+_output/
 
 # Dependency directories (remove the comment below to include it)
 vendor/
@@ -25,6 +26,10 @@ bin/
 # Cert
 .ocmconfig
 multicluster_ca
+hack/deploy/cert-*
+hack/deploy/controlplane/cert/*
+hack/deploy/controlplane/cert*
+hack/deploy/etcd/cert*
 
 # Test
 test/resources

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ verify: verify-gocilint
 all: clean vendor build run
 .PHONY: all
 
-run:
+run: build
 	hack/start-multicluster-controlplane.sh
 .PHONY: run
 

--- a/hack/deploy/.gitignore
+++ b/hack/deploy/.gitignore
@@ -1,6 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-cert-*
-controlplane/cert
-controlplane/cert*
-etcd/cert*

--- a/hack/deploy/agent/deployment.yaml
+++ b/hack/deploy/agent/deployment.yaml
@@ -1,0 +1,45 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: multicluster-controlplane-agent
+  labels:
+    app: multicluster-controlplane-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multicluster-controlplane-agent
+  template:
+    metadata:
+      labels:
+        app: multicluster-controlplane-agent
+    spec:
+      containers:
+      - name: agent
+        image: quay.io/open-cluster-management/multicluster-controlplane
+        imagePullPolicy: IfNotPresent
+        args:
+          - "/multicluster-controlplane"
+          - "agent"
+          - "--cluster-name=cluster1"
+          - "--bootstrap-kubeconfig=/spoke/bootstrap/kubeconfig"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          runAsNonRoot: true
+        volumeMounts:
+        - name: bootstrap-secret
+          mountPath: "/spoke/bootstrap"
+          readOnly: true
+        - name: hub-kubeconfig
+          mountPath: "/spoke/hub-kubeconfig"
+      volumes:
+      - name: bootstrap-secret
+        secret:
+          secretName: bootstrap-secret
+      - name: hub-kubeconfig
+        emptyDir:
+          medium: Memory

--- a/hack/deploy/controlplane/deployment.yaml
+++ b/hack/deploy/controlplane/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
           - "/multicluster-controlplane"
+          - "server"
           - "--authorization-mode=RBAC"
           - "--enable-bootstrap-token-auth"
           - "--service-account-key-file=/controlplane/cert/kube-serviceaccount.key"
@@ -45,6 +46,7 @@ spec:
           - "--service-account-issuer=https://kubernetes.default.svc"
           - "--external-hostname=API_HOST"
           - "--profiling=false"
+          - "--self-management"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/hack/deploy/controlplane/external-etcd-patch.yaml
+++ b/hack/deploy/controlplane/external-etcd-patch.yaml
@@ -9,6 +9,7 @@ spec:
       - name: controlplane
         args:
           - "/multicluster-controlplane"
+          - "server"
           - "--authorization-mode=RBAC"
           - "--enable-bootstrap-token-auth"
           - "--service-account-key-file=/controlplane/cert/kube-serviceaccount.key"

--- a/hack/start-multicluster-controlplane-agent.sh
+++ b/hack/start-multicluster-controlplane-agent.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+KUBE_ROOT=$(pwd)
+GO_OUT=${GO_OUT:-"${KUBE_ROOT}/bin"}
+
+KUBECONFIG=${KUBECONFIG:-"$HOME/.kube/config"}
+CLUSTER_NAME=${CLUSTER_NAME:-"cluster1"}
+
+BOOTSTRAP_KUBECONFIG=""
+if [ ! "$BOOTSTRAP_KUBECONFIG" ]; then
+    echo "BOOTSTRAP_KUBECONFIG is required"
+    exit 1
+fi
+
+hubkubeconfigdir="${KUBE_ROOT}/_output/spoke/hub-kubeconfig"
+mkdir -p $hubkubeconfigdir
+
+kubectl delete ns open-cluster-management-agent --ignore-not-found
+kubectl create ns open-cluster-management-agent
+
+"${GO_OUT}/multicluster-controlplane" \
+"agent" \
+--cluster-name="${CLUSTER_NAME}" \
+--bootstrap-kubeconfig="${BOOTSTRAP_KUBECONFIG}" \
+--hub-kubeconfig-dir="${hubkubeconfigdir}" \
+--spoke-kubeconfig="$KUBECONFIG"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,0 +1,169 @@
+// Copyright Contributors to the Open Cluster Management project
+package agent
+
+import (
+	"context"
+	"embed"
+
+	"github.com/spf13/pflag"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+
+	"open-cluster-management.io/registration/pkg/spoke"
+)
+
+//go:embed crds
+var crds embed.FS
+
+var crdStaticFiles = []string{
+	"crds/appliedmanifestworks.work.open-cluster-management.io.crd.yaml",
+	"crds/clusterclaims.clusters.open-cluster-management.io.crd.yaml",
+}
+
+var (
+	genericScheme = runtime.NewScheme()
+	genericCodecs = serializer.NewCodecFactory(genericScheme)
+	genericCodec  = genericCodecs.UniversalDeserializer()
+)
+
+func init() {
+	utilruntime.Must(crdv1.AddToScheme(genericScheme))
+}
+
+type AgentOptions struct {
+	registrationAgent *spoke.SpokeAgentOptions
+	kubeConfig        *rest.Config
+	eventRecorder     events.Recorder
+}
+
+func NewAgentOptions() *AgentOptions {
+	return &AgentOptions{
+		registrationAgent: spoke.NewSpokeAgentOptions(),
+		eventRecorder:     events.NewInMemoryRecorder("managed-cluster-agents"),
+	}
+}
+
+func (o *AgentOptions) AddFlags(fs *pflag.FlagSet) {
+	o.registrationAgent.AddFlags(fs)
+}
+
+func (o *AgentOptions) WithClusterName(clusterName string) *AgentOptions {
+	o.registrationAgent.ClusterName = clusterName
+	return o
+}
+
+func (o *AgentOptions) WithSpokeKubeconfig(kubeConfig *rest.Config) *AgentOptions {
+	o.kubeConfig = kubeConfig
+	return o
+}
+
+func (o *AgentOptions) WithBootstrapKubeconfig(bootstrapKubeconfig string) *AgentOptions {
+	o.registrationAgent.BootstrapKubeconfig = bootstrapKubeconfig
+	return o
+}
+
+func (o *AgentOptions) WithHubKubeconfigDir(hubKubeconfigDir string) *AgentOptions {
+	o.registrationAgent.HubKubeconfigDir = hubKubeconfigDir
+	return o
+}
+
+func (o *AgentOptions) Complete() error {
+	if o.kubeConfig != nil {
+		return nil
+	}
+
+	if o.registrationAgent.SpokeKubeconfig == "" {
+		kubeConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return err
+		}
+
+		o.kubeConfig = kubeConfig
+		return nil
+	}
+
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", o.registrationAgent.SpokeKubeconfig)
+	if err != nil {
+		return err
+	}
+
+	o.kubeConfig = kubeConfig
+	return nil
+}
+
+func (o *AgentOptions) Validate() error {
+	return nil
+}
+
+func (o *AgentOptions) RunAgent(ctx context.Context) error {
+	if err := o.Complete(); err != nil {
+		return err
+	}
+
+	if err := o.Validate(); err != nil {
+		return err
+	}
+
+	apiExtensionsClient, err := apiextensionsclient.NewForConfig(o.kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	if err := o.ensureCRDs(ctx, apiExtensionsClient); err != nil {
+		return err
+	}
+
+	klog.Infof("Starting registration agent")
+	go func() {
+		ctrlContext := &controllercmd.ControllerContext{
+			KubeConfig:    o.kubeConfig,
+			EventRecorder: o.eventRecorder,
+		}
+
+		if err := o.registrationAgent.RunSpokeAgent(ctx, ctrlContext); err != nil {
+			klog.Fatal(err)
+		}
+	}()
+
+	return nil
+}
+
+func (o *AgentOptions) ensureCRDs(ctx context.Context, client apiextensionsclient.Interface) error {
+	for _, crdFileName := range crdStaticFiles {
+		template, err := crds.ReadFile(crdFileName)
+		if err != nil {
+			return err
+		}
+
+		objData := assets.MustCreateAssetFromTemplate(crdFileName, template, nil).Data
+		obj, _, err := genericCodec.Decode(objData, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		switch required := obj.(type) {
+		case *crdv1.CustomResourceDefinition:
+			if _, _, err := resourceapply.ApplyCustomResourceDefinitionV1(
+				ctx,
+				client.ApiextensionsV1(),
+				o.eventRecorder,
+				required,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/agent/crds/appliedmanifestworks.work.open-cluster-management.io.crd.yaml
+++ b/pkg/agent/crds/appliedmanifestworks.work.open-cluster-management.io.crd.yaml
@@ -1,0 +1,84 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: appliedmanifestworks.work.open-cluster-management.io
+spec:
+  group: work.open-cluster-management.io
+  names:
+    kind: AppliedManifestWork
+    listKind: AppliedManifestWorkList
+    plural: appliedmanifestworks
+    singular: appliedmanifestwork
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: AppliedManifestWork represents an applied manifestwork on managed cluster that is placed on a managed cluster. An AppliedManifestWork links to a manifestwork on a hub recording resources deployed in the managed cluster. When the agent is removed from managed cluster, cluster-admin on managed cluster can delete appliedmanifestwork to remove resources deployed by the agent. The name of the appliedmanifestwork must be in the format of {hash of hub's first kube-apiserver url}-{manifestwork name}
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents the desired configuration of AppliedManifestWork.
+              type: object
+              properties:
+                agentID:
+                  description: AgentID represents the ID of the work agent who is to handle this AppliedManifestWork.
+                  type: string
+                hubHash:
+                  description: HubHash represents the hash of the first hub kube apiserver to identify which hub this AppliedManifestWork links to.
+                  type: string
+                manifestWorkName:
+                  description: ManifestWorkName represents the name of the related manifestwork on the hub.
+                  type: string
+            status:
+              description: Status represents the current status of AppliedManifestWork.
+              type: object
+              properties:
+                appliedResources:
+                  description: AppliedResources represents a list of resources defined within the manifestwork that are applied. Only resources with valid GroupVersionResource, namespace, and name are suitable. An item in this slice is deleted when there is no mapped manifest in manifestwork.Spec or by finalizer. The resource relating to the item will also be removed from managed cluster. The deleted resource may still be present until the finalizers for that resource are finished. However, the resource will not be undeleted, so it can be removed from this list and eventual consistency is preserved.
+                  type: array
+                  items:
+                    description: AppliedManifestResourceMeta represents the group, version, resource, name and namespace of a resource. Since these resources have been created, they must have valid group, version, resource, namespace, and name.
+                    type: object
+                    required:
+                      - name
+                      - resource
+                      - version
+                    properties:
+                      group:
+                        description: Group is the API Group of the Kubernetes resource, empty string indicates it is in core group.
+                        type: string
+                      name:
+                        description: Name is the name of the Kubernetes resource.
+                        type: string
+                      namespace:
+                        description: Name is the namespace of the Kubernetes resource, empty string indicates it is a cluster scoped resource.
+                        type: string
+                      resource:
+                        description: Resource is the resource name of the Kubernetes resource.
+                        type: string
+                      uid:
+                        description: UID is set on successful deletion of the Kubernetes resource by controller. The resource might be still visible on the managed cluster after this field is set. It is not directly settable by a client.
+                        type: string
+                      version:
+                        description: Version is the version of the Kubernetes resource.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/agent/crds/clusterclaims.clusters.open-cluster-management.io.crd.yaml
+++ b/pkg/agent/crds/clusterclaims.clusters.open-cluster-management.io.crd.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterclaims.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ClusterClaim
+    listKind: ClusterClaimList
+    plural: clusterclaims
+    singular: clusterclaim
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "ClusterClaim represents cluster information that a managed cluster claims ClusterClaims with well known names include,  1. id.k8s.io, it contains a unique identifier for the cluster.  2. clusterset.k8s.io, it contains an identifier that relates the cluster     to the ClusterSet in which it belongs. \n ClusterClaims created on a managed cluster will be collected and saved into the status of the corresponding ManagedCluster on hub."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the attributes of the ClusterClaim.
+              type: object
+              properties:
+                value:
+                  description: Value is a claim-dependent string
+                  type: string
+                  maxLength: 1024
+                  minLength: 1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -1,0 +1,47 @@
+// Copyright Contributors to the Open Cluster Management project
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog"
+
+	"open-cluster-management.io/multicluster-controlplane/pkg/agent"
+)
+
+func NewAgent() *cobra.Command {
+	agentOptions := agent.NewAgentOptions()
+
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Start a Multicluster Controlplane Agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shutdownCtx, cancel := context.WithCancel(context.TODO())
+
+			shutdownHandler := server.SetupSignalHandler()
+			go func() {
+				defer cancel()
+				<-shutdownHandler
+				klog.Infof("Received SIGTERM or SIGINT signal, shutting down agent.")
+			}()
+
+			ctx, terminate := context.WithCancel(shutdownCtx)
+			defer terminate()
+
+			fmt.Println("haha")
+			if err := agentOptions.RunAgent(ctx); err != nil {
+				return err
+			}
+
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	agentOptions.AddFlags(flags)
+	return cmd
+}

--- a/pkg/cmd/controller/controller.go
+++ b/pkg/cmd/controller/controller.go
@@ -1,0 +1,54 @@
+// Copyright Contributors to the Open Cluster Management project
+package controller
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"open-cluster-management.io/multicluster-controlplane/pkg/servers"
+	"open-cluster-management.io/multicluster-controlplane/pkg/servers/options"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	cliflag "k8s.io/component-base/cli/flag"
+	logsapi "k8s.io/component-base/logs/api/v1"
+	"k8s.io/component-base/version/verflag"
+)
+
+func NewController() *cobra.Command {
+	options := options.NewServerRunOptions()
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Start a Multicluster Controlplane Server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+			cliflag.PrintFlags(cmd.Flags())
+
+			if err := logsapi.ValidateAndApply(options.Logs, utilfeature.DefaultFeatureGate); err != nil {
+				return err
+			}
+
+			stopChan := genericapiserver.SetupSignalHandler()
+			if err := options.Complete(stopChan); err != nil {
+				return err
+			}
+
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			return servers.NewServer(*options).Start(stopChan)
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if len(arg) > 0 {
+					return fmt.Errorf("%q does not take any arguments, got %q", cmd.CommandPath(), args)
+				}
+			}
+			return nil
+		},
+	}
+	options.AddFlags(cmd.Flags())
+	return cmd
+}

--- a/pkg/controllers/ocmcontroller/ocmagent.go
+++ b/pkg/controllers/ocmcontroller/ocmagent.go
@@ -1,0 +1,120 @@
+// Copyright Contributors to the Open Cluster Management project
+package ocmcontroller
+
+import (
+	"context"
+	"os"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
+
+	clusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"open-cluster-management.io/multicluster-controlplane/pkg/agent"
+)
+
+const (
+	// TODO consider to put this in the api repo as a common const
+	defaultOCMAgentNamespace = "open-cluster-management-agent"
+	selfManagedClusterName   = "local-cluster"
+)
+
+func InstallAgent(controlplaneCertDir string) func(<-chan struct{}, *aggregatorapiserver.Config) error {
+	return func(stopCh <-chan struct{}, aggregatorConfig *aggregatorapiserver.Config) error {
+		go func() {
+			restConfig := aggregatorConfig.GenericConfig.LoopbackClientConfig
+			restConfig.ContentType = "application/json"
+
+			kubeClient, err := kubernetes.NewForConfig(restConfig)
+			if err != nil {
+				klog.Fatalf("failed to kube client, %v", err)
+			}
+
+			clusterClient, err := clusterclient.NewForConfig(restConfig)
+			if err != nil {
+				klog.Fatalf("failed to cluster client, %v", err)
+			}
+
+			ctx := GoContext(stopCh)
+
+			agentNamespace := getAgentNamespace()
+			if err := createNamespace(ctx, kubeClient, agentNamespace); err != nil {
+				klog.Fatalf("failed to create ocm agent namespace, %v", err)
+			}
+
+			if err := createNamespace(ctx, kubeClient, selfManagedClusterName); err != nil {
+				klog.Fatalf("failed to create self managed cluster namespace, %v", err)
+			}
+
+			if err := createSelfManagedCluster(ctx, clusterClient); err != nil {
+				klog.Fatalf("failed to create self managed cluster, %v", err)
+			}
+
+			bootstrapKubeConfig := path.Join(controlplaneCertDir, "kube-aggregator.kubeconfig")
+			// TODO also need with feature gates
+			klusterletAgent := agent.NewAgentOptions().
+				WithClusterName(selfManagedClusterName).
+				WithSpokeKubeconfig(restConfig).
+				WithBootstrapKubeconfig(bootstrapKubeConfig).
+				WithHubKubeconfigDir("/tmp")
+
+			if err := klusterletAgent.RunAgent(ctx); err != nil {
+				klog.Fatalf("failed to start agents, %v", err)
+			}
+		}()
+		return nil
+	}
+}
+
+func createNamespace(ctx context.Context, kubeClient kubernetes.Interface, ns string) error {
+	_, err := kubeClient.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err := kubeClient.CoreV1().Namespaces().Create(
+			ctx,
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		return err
+	}
+
+	return err
+}
+
+func createSelfManagedCluster(ctx context.Context, clusterClient clusterclient.Interface) error {
+	_, err := clusterClient.ClusterV1().ManagedClusters().Get(ctx, selfManagedClusterName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err := clusterClient.ClusterV1().ManagedClusters().Create(
+			ctx,
+			&clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: selfManagedClusterName,
+				},
+				Spec: clusterv1.ManagedClusterSpec{
+					HubAcceptsClient: true,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		return err
+	}
+
+	return err
+}
+
+func getAgentNamespace() string {
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return defaultOCMAgentNamespace
+	}
+
+	return string(nsBytes)
+}

--- a/pkg/servers/options/options.go
+++ b/pkg/servers/options/options.go
@@ -91,6 +91,10 @@ type ServerRunOptions struct {
 	ExtraOptions  *ExtraOptions
 
 	KubeControllerManagerOptions *kubectrmgroptions.KubeControllerManagerOptions
+
+	// EnableSelfManagement register the current cluster self as a managed cluster
+	EnableSelfManagement bool
+	ControlplaneCertDir  string
 }
 
 type ExtraOptions struct {
@@ -157,6 +161,7 @@ func NewServerRunOptions() *ServerRunOptions {
 			EmbeddedEtcd: NewEmbeddedEtcd(),
 		},
 		KubeControllerManagerOptions: kubeControllerManagerOptions,
+		ControlplaneCertDir:          "/controlplane/cert",
 	}
 }
 
@@ -177,9 +182,10 @@ func (options *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&options.ServiceAccountSigningKeyFile, "service-account-signing-key-file", options.ServiceAccountSigningKeyFile, "Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.")
 	fs.StringVar(&options.ServiceClusterIPRanges, "service-cluster-ip-range", options.ServiceClusterIPRanges, "A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.")
-	fs.BoolVar(&options.EnableAggregatorRouting, "enable-aggregator-routing", options.EnableAggregatorRouting,
-		"Turns on aggregator routing requests to endpoints IP rather than cluster IP.")
+	fs.BoolVar(&options.EnableAggregatorRouting, "enable-aggregator-routing", options.EnableAggregatorRouting, "Turns on aggregator routing requests to endpoints IP rather than cluster IP.")
 	fs.StringVar(&options.ExtraOptions.ClientKeyFile, "client-key-file", options.ExtraOptions.ClientKeyFile, "client cert key file")
+	fs.BoolVar(&options.EnableSelfManagement, "self-management", options.EnableSelfManagement, "Register the current controlplane as a managed cluster.")
+	fs.StringVar(&options.ControlplaneCertDir, "controlplane-cert-dir", options.ControlplaneCertDir, "The controlplane cert directory.")
 }
 
 // Complete set default Options.

--- a/pkg/servers/server.go
+++ b/pkg/servers/server.go
@@ -37,6 +37,10 @@ func NewServer(options options.ServerRunOptions) *server {
 	s.AddController("multicluster-controlplane-crd", ocmcontroller.InstallCrd)
 	s.AddController("multicluster-controlplane-registration-resource", ocmcontroller.InstallHubResource)
 	s.AddController("multicluster-controlplane-controllers", ocmcontroller.InstallControllers)
+
+	if options.EnableSelfManagement {
+		s.AddController("multicluster-controlplane-agents", ocmcontroller.InstallAgent(options.ControlplaneCertDir))
+	}
 	return s
 }
 

--- a/test/bin/setup-integration.sh
+++ b/test/bin/setup-integration.sh
@@ -32,6 +32,7 @@ function start_apiserver {
     apiserver_log=${project_dir}/test/resources/integration/kube-apiserver.log
 
     ${CONTROLPLANE_SUDO} "${controlplane_bin}/multicluster-controlplane" \
+    "server" \
     --authorization-mode="RBAC"  \
     --v="7" \
     --enable-bootstrap-token-auth \


### PR DESCRIPTION
Add the sub command for `multicluster-controlplane`

```
# start one multicluster controlplane server
multicluster-controlplane server

# start one multicluster controlplane server and register itself to the controlplane
multicluster-controlplane server --self-management

# only start multicluster-controlplane agent, agent includes: registration-agent and work-agent (TODO)
multicluster-controlplane agent
```
