### PR TITLE
Expose RegistrationAgent and KubeConfig

### DIFF
--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server"
@@ -31,7 +30,6 @@ func NewAgent() *cobra.Command {
 			ctx, terminate := context.WithCancel(shutdownCtx)
 			defer terminate()
 
-			fmt.Println("haha")
 			if err := agentOptions.RunAgent(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
The multicluster-controlplane is a lib. Expose RegistrationAgent and KubeConfig so that it can be used as a reference.