### PR TITLE
Replace tilde with $HOME

### DIFF
--- a/hack/deploy-multicluster-controlplane.sh
+++ b/hack/deploy-multicluster-controlplane.sh
@@ -5,7 +5,7 @@ REPO_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})/.." ; pwd -P)"
 
 KUBECTL=${KUBECTL:-"kubectl"}
 KUSTOMIZE=${KUSTOMIZE:-"kustomize"}
-KUBECONFIG=${KUBECONFIG:-"~/.kube/config"}
+KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
 
 if ! command -v $KUBECTL >/dev/null 2>&1; then
     echo "ERROR: command $KUBECTL is not found"


### PR DESCRIPTION
Thanks for updating the deploy script. I'm trying it out.
When I run `make deploy`, I get the following error:

```bash
+ '[' '!' -f '~/.kube/config' ']'
+ echo 'ERROR: kubeconfig file ~/.kube/config is not found'
ERROR: kubeconfig file ~/.kube/config is not found
```

This is because tildes within double quotes are not expanded.
https://askubuntu.com/questions/1192981/why-isnt-tilde-recognised-as-home-folder-in-this-case