### PR TITLE
Change loadConfigFromFile to return os.IsNotExist error

### DIFF
--- a/pkg/servers/configs/configs.go
+++ b/pkg/servers/configs/configs.go
@@ -74,7 +74,7 @@ func (c *ControlplaneRunConfig) IsEmbedEtcd() bool {
 func loadConfigFromFile(configDir string) (*ControlplaneRunConfig, error) {
 	configFile := path.Join(configDir, "ocmconfig.yaml")
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
-		return nil, nil
+		return nil, err
 	}
 
 	configFileData, err := os.ReadFile(configFile)


### PR DESCRIPTION
This change makes it easier to identify the cause of abnormal exit.

Before

```bash
% go run cmd/server/main.go server
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x34b8f21]

goroutine 1 [running]:
open-cluster-management.io/multicluster-controlplane/pkg/servers/configs.LoadConfig({0x423fd6f?, 0x40?})
	/Users/ohkinozomu/projects/multicluster-controlplane/pkg/servers/configs/configs.go:51 +0x41
open-cluster-management.io/multicluster-controlplane/pkg/servers/options.(*ServerRunOptions).Complete(0xc00015f400, 0xc000122a80)
	/Users/ohkinozomu/projects/multicluster-controlplane/pkg/servers/options/options.go:256 +0x52
open-cluster-management.io/multicluster-controlplane/pkg/cmd/controller.NewController.func1(0xc000115800?, {0x6751cd8?, 0x0?, 0x0?})
	/Users/ohkinozomu/projects/multicluster-controlplane/pkg/cmd/controller/controller.go:33 +0xa6
github.com/spf13/cobra.(*Command).execute(0xc000115800, {0x6751cd8, 0x0, 0x0})
	/Users/ohkinozomu/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000115500)
	/Users/ohkinozomu/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:1040 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/ohkinozomu/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:968
k8s.io/component-base/cli.run(0xc000115500)
	/Users/ohkinozomu/go/pkg/mod/k8s.io/component-base@v0.26.2/cli/run.go:146 +0x317
k8s.io/component-base/cli.Run(0xc0000061a0?)
	/Users/ohkinozomu/go/pkg/mod/k8s.io/component-base@v0.26.2/cli/run.go:46 +0x1d
main.main()
	/Users/ohkinozomu/projects/multicluster-controlplane/cmd/server/main.go:26 +0x1e
exit status 2
```

After

```bash
% go run cmd/server/main.go server
E0322 15:55:21.936048    4672 run.go:74] "command failed" err="stat /controlplane_config/ocmconfig.yaml: no such file or directory"
exit status 1
```