### PR TITLE
Set ETCD_SNAPSHOT_COUNT as 5000

### DIFF
--- a/charts/multicluster-controlplane/templates/deployment.yaml
+++ b/charts/multicluster-controlplane/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- end }}
+        env:
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "{{ .Values.etcd.snapshotCount }}"
         livenessProbe:
           httpGet:
             path: /livez

--- a/charts/multicluster-controlplane/values.yaml
+++ b/charts/multicluster-controlplane/values.yaml
@@ -24,6 +24,7 @@ apiserver:
   generateCA: false
 etcd:
   mode: "embed"
+  snapshotCount: 5000
   servers: []
   ca: ""
   cert: ""

--- a/hack/deploy/etcd/statefulset.yaml
+++ b/hack/deploy/etcd/statefulset.yaml
@@ -33,6 +33,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "5000"
         command:
           - "/bin/sh"
           - "-ecx"


### PR DESCRIPTION
Set ETCD_SNAPSHOT_COUNT as 5000 to reduce the memory consumption - https://etcd.io/docs/v3.5/tuning/#snapshots. the default value is 100000. 
refer to https://github.com/stolostron/multicluster-controlplane/pull/55 for more details