### PR TITLE
Always create service for multicluster controlplane

### DIFF
--- a/charts/multicluster-controlplane/templates/_validate.tpl
+++ b/charts/multicluster-controlplane/templates/_validate.tpl
@@ -18,6 +18,6 @@
             {{- fail "nodeport.port should be set while nodeport is enabled" }}
         {{- end }}
     {{- else }}
-        {{/* service not exposed */}}
+        {{/* service exposed as ClusterIP */}}
     {{- end }}
 {{- end }}

--- a/charts/multicluster-controlplane/templates/service.yaml
+++ b/charts/multicluster-controlplane/templates/service.yaml
@@ -1,5 +1,4 @@
 {{- include "validate.exposeService" . }}
-{{- if or (eq .Values.nodeport.enabled true) (or (eq .Values.loadbalancer.enabled true) (eq .Values.route.enabled true)) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,6 +16,8 @@ spec:
   {{- end }}
   {{- else if eq .Values.nodeport.enabled true }}
   type: NodePort
+  {{- else }}
+  type: ClusterIP
   {{- end }}
   selector:
     app: multicluster-controlplane
@@ -28,4 +29,3 @@ spec:
       {{- if eq .Values.nodeport.enabled true }}
       nodePort: {{ .Values.nodeport.port }}
       {{- end }}
-{{- end }}


### PR DESCRIPTION
This is required to use ingress to expose a single IP for mc-cp and cluster-proxy via ingress-nginx